### PR TITLE
X00QD: fingerprint: use libhidlbase-v32 for goodix

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -527,6 +527,7 @@ PRODUCT_PACKAGES += \
 
 # VNDK
 PRODUCT_COPY_FILES += \
+    prebuilts/vndk/v32/arm64/arch-arm64-armv8-a/shared/vndk-sp/libhidlbase.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libhidlbase-v32.so \
     prebuilts/vndk/v34/arm64/arch-arm64-armv8-a/shared/vndk-core/libcrypto.so:$(TARGET_COPY_OUT_VENDOR)/lib64/libcrypto-v34.so \
 
 # Wifi

--- a/extract-files.sh
+++ b/extract-files.sh
@@ -65,6 +65,10 @@ function blob_fixup() {
     system/lib64/libfm-hci.so | system/lib64/libwfdnative.so | system/lib/libfm-hci.so | system/lib/libwfdnative.so)
         "${PATCHELF}" --remove-needed "android.hidl.base@1.0.so" "${2}"
         ;;
+    # fingerprint: use libhidlbase-v32 for goodix
+    vendor/lib64/libvendor.goodix.hardware.fingerprintextension@1.0.so)
+        grep -q "libhidlbase-v32.so" "${2}" || "${PATCHELF}" --replace-needed "libhidlbase.so" "libhidlbase-v32.so" "${2}"
+        ;;
     esac
 }
 

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,3 +1,1 @@
 git clone https://gitlab.com/dragonsxbr/vendor_asus-firmware -b twelve-wip vendor/asus-firmware
-rm -rf system/libhidl
-git clone https://github.com/RisingOS-Revived/android_system_libhidl system/libhidl


### PR DESCRIPTION
instead of patching the system/libhidl manually

inspired from https://github.com/LineageOS/android_device_asus_X00TD/commit/5eb709785e93bd580f3998faa29e9fc498c90f0c